### PR TITLE
Payrix Gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ Gemfile*.lock
 .rvmrc
 /doc/
 .ruby-version
+# asdf
+.tool-versions
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'rubocop', '~> 1.14.0', require: false
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
   gem 'braintree', '>= 4.14.0'
+  gem 'byebug'
   gem 'jose', '~> 1.1.3'
   gem 'jwe'
   gem 'mechanize'

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :test, :remote_test do
   gem 'byebug'
   gem 'jose', '~> 1.1.3'
   gem 'jwe'
+  gem 'm' # run minitest by line number like you can easily do in rspec
   gem 'mechanize'
   gem 'timecop'
 end

--- a/lib/active_merchant/billing/gateways/payrix.rb
+++ b/lib/active_merchant/billing/gateways/payrix.rb
@@ -1,3 +1,5 @@
+require_relative '../../../payrix/create_transaction'
+
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class PayrixGateway < Gateway
@@ -23,15 +25,124 @@ module ActiveMerchant #:nodoc:
         invalid_card_number: 'invalid_card_number'
       }
 
+      def self.success_message
+        'Request Successful'
+      end
+
+      def self.api_key(options:, gateway:)
+        options[:api_key] || gateway.options[:api_key]
+      end
+
       def initialize(options = {})
         requires!(options, :merchant_id, :api_key)
         super
       end
 
-      def purchase(money, payment, options = {})
-        post = build_purchase_request(money, payment, options)
+      class MapPayrixErrorCodeToActiveMerchantErrorCode
+        # NOTE: standardized error codes from ActiveMerchant
+        # {
+        #   incorrect_number: 'incorrect_number',
+        #   invalid_number: 'invalid_number',
+        #   invalid_expiry_date: 'invalid_expiry_date',
+        #   invalid_cvc: 'invalid_cvc',
+        #   expired_card: 'expired_card',
+        #   incorrect_cvc: 'incorrect_cvc',
+        #   incorrect_zip: 'incorrect_zip',
+        #   incorrect_address: 'incorrect_address',
+        #   incorrect_pin: 'incorrect_pin',
+        #   card_declined: 'card_declined',
+        #   processing_error: 'processing_error',
+        #   call_issuer: 'call_issuer',
+        #   pickup_card: 'pick_up_card',
+        #   config_error: 'config_error',
+        #   test_mode_live_card: 'test_mode_live_card',
+        #   unsupported_feature: 'unsupported_feature',
+        #   invalid_amount: 'invalid_amount'
+        # }
+        def call(payrix_error_code:)
+          case payrix_error_code
+          when 'invalid_auth'
+            PayrixGateway::STANDARD_ERROR_CODE[:config_error]
+          end
+        end
+      end
 
-        commit('txns', post, options)
+      def purchase(
+        money,
+        payment,
+        options = {}
+      )
+        params = BuildPurchaseRequestParams.new.call(money: money, payment: payment, options: options, gateway: self)
+        api_key = self.class.api_key(options: options, gateway: self)
+        env = test? ? :test : :production
+        # TODO: purchase timeout configurable by env var? or whatever is idiomatic in ActiveMerchant
+        timeout_ms = 5000
+
+        result = Payrix::CreateTransaction.new.call(params: params, api_key: api_key, env: env, timeout_ms: timeout_ms)
+        # byebug
+        if result.success?
+          # TODO: Response for success
+        else
+          success = false
+          # ex: "Field: , Code: 4, Severity: 3, Msg: Invalid authentication, ErrorCode: invalid_auth"
+          error_message = result.error_message
+          # ex: [{:code=>4, :severity=>3, :msg=>"Invalid authentication", :errorCode=>"invalid_auth"}]
+          errors = result.errors
+          payrix_error_code = errors.first[:errorCode]
+          error_code = MapPayrixErrorCodeToActiveMerchantErrorCode.new.call(payrix_error_code: payrix_error_code)
+
+          params = {}
+          options = {
+            authorization: nil,
+            # TODO: extract this from the response
+            avs_result: nil,
+            # TODO: extract this from the response
+            cvv_result: nil,
+            test: test?,
+            error_code: error_code
+          }
+
+          # Response docs: https://www.rubydoc.info/github/Shopify/active_merchant/ActiveMerchant/Billing/Response
+          return Response.new(success, error_message, params, options)
+        end
+      end
+
+      class BuildPurchaseRequestParams
+        def call(gateway:, money:, payment:, options:)
+          params = {}
+          self.class.add_merchant!(params: params, options: options)
+          self.class.add_payment!(params: params, payment: payment)
+          self.class.add_invoice!(params: params, money: money, options: options, gateway: gateway)
+          self.class.add_transaction_details!(params: params, options: options)
+          params
+        end
+
+        def self.add_customer_data!(params:, options:); end
+
+        def self.add_address!(params:, creditcard:, options:); end
+
+        def self.add_merchant!(params:, options:)
+          params[:merchant] = options[:merchant_id]
+        end
+
+        def self.add_payment!(params:, payment:)
+          params[:payment] = {
+            method: CREDIT_CARD_CODES[:"#{payment.brand}"],
+            number: payment.number,
+            cvv: payment.verification_value
+          }
+        end
+
+        def self.add_invoice!(params:, money:, options:, gateway:)
+          params[:total] = gateway.send(:amount, money)
+          params[:currency] = (options[:currency] || gateway.send(:currency, money))
+        end
+
+        def self.add_transaction_details!(params:, options:)
+          params[:type] = options[:type]
+          params[:origin] = options[:origin]
+          params[:expiration] = options[:expiration]
+        end
       end
 
       def authorize(money, payment, options = {})
@@ -58,11 +169,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def supports_scrubbing?
+        # TODO: change this to true? We need to support scrubbing no matter what, right?
         false
       end
 
       def scrub(transcript)
-        #transcript.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?').
+        # transcript.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?').
         #  gsub(/(\\?"number\\?":\\?")\d+/, '\1[FILTERED]').
         #  gsub(/(\\?"cvv\\?":\\?")\d+/, '\1[FILTERED]').
         #  gsub(/(\\?"method\\?":\\?")\d+/, '\1[FILTERED]').
@@ -71,47 +183,11 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      def build_purchase_request(money, payment, options)
-        post = {}
-        add_merchant(post, options)
-        add_payment(post, payment)
-        add_invoice(post, money, options)
-        add_transaction_details(post, options)
-        post
-      end
-
-      def add_customer_data(post, options); end
-
-      def add_address(post, creditcard, options); end
-
-      def add_merchant(post, options)
-        post[:merchant] = options[:merchant_id] || @options[:merchant_id]
-      end
-
-      def add_payment(post, payment)
-        post[:payment] = {
-          method: CREDIT_CARD_CODES[:"#{payment.brand}"],
-          number: payment.number,
-          cvv: payment.verification_value
-        }
-      end
-
-      def add_invoice(post, money, options)
-        post[:total] = amount(money)
-        post[:currency] = (options[:currency] || currency(money))
-      end
-
-      def add_transaction_details(post, options)
-        post[:type] = options[:type] || @options[:type]
-        post[:origin] = options[:origin] || @options[:origin]
-        post[:expiration] = options[:expiration] || @options[:expiration]
-      end
-
       def parse(body)
         JSON.parse(body)
       end
 
-      def commit(action, parameters, options={})
+      def commit(action, parameters, options = {})
         url = (test? ? test_url : live_url)
         endpoint = url + '/' + action
         response = parse(ssl_post(endpoint, parameters.to_json, auth_headers(options)))
@@ -131,21 +207,21 @@ module ActiveMerchant #:nodoc:
       def auth_headers(options)
         {
           'Content-Type' => 'application/json',
-          'APIKEY' => options[:api_key] || @options[:api_key]
+          'APIKEY' => self.class.api_key(gateway: self, options: options)
         }
       end
 
       def success_from(response)
-        response["response"]["errors"].empty? ? true : false
+        response['response']['errors'].empty? ? true : false
       end
 
       def message_from(response)
-        return "Request Successful" if success_from(response)
+        return self.success_message if success_from(response)
       end
 
       def authorization_from(response)
-        id = response.try(:[], "response").try(:[], "data").first.try(:[], "id")
-        total = response.try(:[], "response").try(:[], "data").first.try(:[], "total")
+        id = response.try(:[], 'response').try(:[], 'data').first.try(:[], 'id')
+        total = response.try(:[], 'response').try(:[], 'data').first.try(:[], 'total')
 
         return '|' if id.blank? && total.blank?
         return "#{id}|" if total.blank?
@@ -154,9 +230,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def error_code_from(response)
-        unless success_from(response)
-          response["response"]["errors"].first["errorCode"]
-        end
+        response['response']['errors'].first['errorCode'] unless success_from(response)
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/payrix.rb
+++ b/lib/active_merchant/billing/gateways/payrix.rb
@@ -21,10 +21,6 @@ module ActiveMerchant #:nodoc:
         discover: '5'
       }
 
-      STANDARD_ERROR_CODE = {
-        invalid_card_number: 'invalid_card_number'
-      }
-
       def self.success_message
         'Request Successful'
       end
@@ -81,7 +77,19 @@ module ActiveMerchant #:nodoc:
         result = Payrix::CreateTransaction.new.call(params: params, api_key: api_key, env: env, timeout_ms: timeout_ms)
         # byebug
         if result.success?
-          # TODO: Response for success
+          success = true
+          error_message = nil
+          params = {}
+          options = {
+            # TODO: extract this from the response
+            authorization: nil,
+            # TODO: extract this from the response
+            avs_result: nil,
+            # TODO: extract this from the response
+            cvv_result: nil,
+            test: test?,
+            error_code: error_code
+          }
         else
           success = false
           # ex: "Field: , Code: 4, Severity: 3, Msg: Invalid authentication, ErrorCode: invalid_auth"
@@ -90,9 +98,9 @@ module ActiveMerchant #:nodoc:
           errors = result.errors
           payrix_error_code = errors.first[:errorCode]
           error_code = MapPayrixErrorCodeToActiveMerchantErrorCode.new.call(payrix_error_code: payrix_error_code)
-
           params = {}
           options = {
+            # TODO: extract this from the response
             authorization: nil,
             # TODO: extract this from the response
             avs_result: nil,
@@ -102,9 +110,10 @@ module ActiveMerchant #:nodoc:
             error_code: error_code
           }
 
-          # Response docs: https://www.rubydoc.info/github/Shopify/active_merchant/ActiveMerchant/Billing/Response
-          return Response.new(success, error_message, params, options)
         end
+
+        # Response docs: https://www.rubydoc.info/github/Shopify/active_merchant/ActiveMerchant/Billing/Response
+        Response.new(success, error_message, params, options)
       end
 
       class BuildPurchaseRequestParams

--- a/lib/active_merchant/billing/gateways/payrix.rb
+++ b/lib/active_merchant/billing/gateways/payrix.rb
@@ -102,9 +102,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_transaction_details(post, options)
-        post[:type] = options[:type] || @options[:type] || '1'
-        post[:origin] = options[:origin] || @options[:origin] || '2'
-        post[:expiration] = options[:expiration] || @options[:expiration] || '0120'
+        post[:type] = options[:type] || @options[:type]
+        post[:origin] = options[:origin] || @options[:origin]
+        post[:expiration] = options[:expiration] || @options[:expiration]
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/payrix.rb
+++ b/lib/active_merchant/billing/gateways/payrix.rb
@@ -19,6 +19,10 @@ module ActiveMerchant #:nodoc:
         discover: '5'
       }
 
+      STANDARD_ERROR_CODE = {
+        invalid_card_number: 'invalid_card_number'
+      }
+
       def initialize(options = {})
         requires!(options, :merchant_id, :api_key)
         super
@@ -139,10 +143,19 @@ module ActiveMerchant #:nodoc:
         return "Request Successful" if success_from(response)
       end
 
-      def authorization_from(response); end
+      def authorization_from(response)
+        id = response.try(:[], "response").try(:[], "data").first.try(:[], "id")
+        total = response.try(:[], "response").try(:[], "data").first.try(:[], "total")
+
+        return '|' if id.blank? && total.blank?
+        return "#{id}|" if total.blank?
+
+        [id, total].join('|')
+      end
 
       def error_code_from(response)
         unless success_from(response)
+          response["response"]["errors"].first["errorCode"]
         end
       end
     end

--- a/lib/active_merchant/billing/gateways/payrix.rb
+++ b/lib/active_merchant/billing/gateways/payrix.rb
@@ -54,11 +54,15 @@ module ActiveMerchant #:nodoc:
       end
 
       def supports_scrubbing?
-        true
+        false
       end
 
       def scrub(transcript)
-        transcript
+        #transcript.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?').
+        #  gsub(/(\\?"number\\?":\\?")\d+/, '\1[FILTERED]').
+        #  gsub(/(\\?"cvv\\?":\\?")\d+/, '\1[FILTERED]').
+        #  gsub(/(\\?"method\\?":\\?")\d+/, '\1[FILTERED]').
+        #  gsub(/(\\?"Apikey\\?":\\?")\d+/, '\1[FILTERED]')
       end
 
       private

--- a/lib/active_merchant/billing/gateways/payrix.rb
+++ b/lib/active_merchant/billing/gateways/payrix.rb
@@ -1,0 +1,116 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class PayrixGateway < Gateway
+      self.test_url = 'https://example.com/test'
+      self.live_url = 'https://example.com/live'
+
+      self.supported_countries = ['US']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = %i[visa master american_express discover]
+
+      self.homepage_url = 'http://www.example.net/'
+      self.display_name = 'New Gateway'
+
+      STANDARD_ERROR_CODE_MAPPING = {}
+
+      def initialize(options = {})
+        requires!(options, :some_credential, :another_credential)
+        super
+      end
+
+      def purchase(money, payment, options = {})
+        post = {}
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_address(post, payment, options)
+        add_customer_data(post, options)
+
+        commit('sale', post)
+      end
+
+      def authorize(money, payment, options = {})
+        post = {}
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_address(post, payment, options)
+        add_customer_data(post, options)
+
+        commit('authonly', post)
+      end
+
+      def capture(money, authorization, options = {})
+        commit('capture', post)
+      end
+
+      def refund(money, authorization, options = {})
+        commit('refund', post)
+      end
+
+      def void(authorization, options = {})
+        commit('void', post)
+      end
+
+      def verify(credit_card, options = {})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript
+      end
+
+      private
+
+      def add_customer_data(post, options); end
+
+      def add_address(post, creditcard, options); end
+
+      def add_invoice(post, money, options)
+        post[:amount] = amount(money)
+        post[:currency] = (options[:currency] || currency(money))
+      end
+
+      def add_payment(post, payment); end
+
+      def parse(body)
+        {}
+      end
+
+      def commit(action, parameters)
+        url = (test? ? test_url : live_url)
+        response = parse(ssl_post(url, post_data(action, parameters)))
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          avs_result: AVSResult.new(code: response['some_avs_response_key']),
+          cvv_result: CVVResult.new(response['some_cvv_response_key']),
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      end
+
+      def success_from(response); end
+
+      def message_from(response); end
+
+      def authorization_from(response); end
+
+      def post_data(action, parameters = {}); end
+
+      def error_code_from(response)
+        unless success_from(response)
+          # TODO: lookup error code for this response
+        end
+      end
+    end
+  end
+end

--- a/lib/payrix.rb
+++ b/lib/payrix.rb
@@ -1,0 +1,2 @@
+module Payrix
+end

--- a/lib/payrix/create_customer.rb
+++ b/lib/payrix/create_customer.rb
@@ -1,0 +1,80 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+require_relative '../payrix'
+
+module Payrix
+  class CreateCustomer
+    private
+
+    attr_reader :post_customer
+
+    def initialize(
+      post_customer: lambda do |endpoint:, api_key:, params:, timeout_ms:|
+        body = URI.encode_www_form(params)
+        headers = {
+          'Content-Type' => 'application/x-www-form-urlencoded',
+          'APIKEY' => api_key
+        }
+        uri = URI.parse(endpoint)
+        request = Net::HTTP::Post.new(uri, headers)
+        request.body = body
+        timeout = timeout_ms / 1000
+
+        response = Net::HTTP.start(uri.hostname, uri.port,
+                                   use_ssl: uri.scheme == 'https',
+                                   open_timeout: timeout,
+                                   write_timeout: timeout,
+                                   read_timeout: timeout) do |http|
+          http.request(request)
+        end
+        body = response.body
+
+        JSON.parse(body, symbolize_names: true)
+      end
+    )
+      @post_customer = post_customer
+    end
+
+    public
+
+    Result = Struct.new(:success?, :error_message, :response, :data, keyword_init: true)
+
+    def call(api_key:, params:, env: :test, timeout_ms: 5000)
+      endpoint = self.class.endpoint(env: env)
+
+      api_response = post_customer.call(
+        params: params,
+        api_key: api_key,
+        endpoint: endpoint,
+        timeout_ms: timeout_ms
+      )
+      errors = api_response[:errors] || api_response.dig(:response, :errors)
+
+      if errors.blank?
+        data = api_response.dig(:response, :data)
+
+        Result.new(success?: true, response: api_response, data: data)
+      else
+        error_message = errors.map do |error|
+          "#{error[:field]}: #{error[:msg]}"
+        end.join(', ')
+
+        Result.new(success?: false, error_message: error_message)
+      end
+    rescue JSON::ParserError => e
+      Result.new(success?: false, error_message: "Failed to parse JSON: #{e.message}")
+    rescue Net::OpenTimeout, Net::ReadTimeout, Net::WriteTimeout => e
+      Result.new(success?: false, error_message: "Request timed out: #{e.message}")
+    end
+
+    def self.endpoint(env:)
+      if %i[production staging].include?(env)
+        'https://api.payrix.com/customers'
+      else
+        'https://test-api.payrix.com/customers'
+      end
+    end
+  end
+end

--- a/lib/payrix/create_refund.rb
+++ b/lib/payrix/create_refund.rb
@@ -1,0 +1,89 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+require_relative '../payrix'
+
+module Payrix
+  class CreateRefund
+    private
+
+    attr_reader :post_refund
+
+    def initialize(
+      post_refund: lambda do |endpoint:, api_key:, params:, timeout_ms:|
+        body = params.to_json
+        headers = {
+          'Content-Type' => 'application/json',
+          'APIKEY' => api_key
+        }
+        uri = URI.parse(endpoint)
+        request = Net::HTTP::Post.new(uri, headers)
+        request.body = body
+        timeout = timeout_ms / 1000
+
+        response = Net::HTTP.start(uri.hostname, uri.port,
+                                   use_ssl: uri.scheme == 'https',
+                                   open_timeout: timeout,
+                                   write_timeout: timeout,
+                                   read_timeout: timeout) do |http|
+          http.request(request)
+        end
+        body = response.body
+
+        JSON.parse(body, symbolize_names: true)
+      end
+    )
+      @post_refund = post_refund
+    end
+
+    public
+
+    Result = Struct.new(:success?, :error_message, :response, :data, keyword_init: true)
+
+    def call(entry_id:, amount:, description: nil, api_key:, env: :test, timeout_ms: 5000)
+      params = {
+        entry: entry_id,
+        amount: amount
+      }
+      params[:description] = description if description
+      endpoint = self.class.endpoint(env: env)
+
+      api_response = post_refund.call(
+        params: params,
+        api_key: api_key,
+        timeout_ms: timeout_ms,
+        endpoint: endpoint
+      )
+      errors = api_response[:errors] || api_response.dig(:response, :errors)
+
+      if errors.blank?
+        data = api_response.dig(:response, :data)
+
+        Result.new(success?: true, response: api_response, data: data)
+      else
+        error_message = errors.map do |error|
+          "#{error[:field]}: #{error[:msg]}"
+        end.join(', ')
+
+        Result.new(success?: false, error_message: error_message)
+      end
+    rescue JSON::ParserError => e
+      Result.new(success?: false, error_message: "Failed to parse JSON: #{e.message}")
+    rescue Net::OpenTimeout, Net::ReadTimeout, Net::WriteTimeout => e
+      Result.new(success?: false, error_message: "Request timed out: #{e.message}")
+    end
+
+    def self.api_key(credentials: Rails.application.credentials)
+      credentials.payrix[:api_key][:test]
+    end
+
+    def self.endpoint(env:)
+      if %i[production staging].include?(env)
+        'https://api.payrix.com/refunds'
+      else
+        'https://test-api.payrix.com/refunds'
+      end
+    end
+  end
+end

--- a/lib/payrix/create_transaction.rb
+++ b/lib/payrix/create_transaction.rb
@@ -1,0 +1,81 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+require_relative '../payrix'
+
+module Payrix
+  class CreateTransaction
+    private
+
+    attr_reader :get_api_response
+
+    def initialize(
+      get_api_response: lambda do |endpoint:, api_key:, params:, timeout_ms:|
+                          body = params.to_json
+                          headers = {
+                            'Content-Type' => 'application/json',
+                            'APIKEY' => api_key
+                          }
+                          uri = URI.parse(endpoint)
+                          request = Net::HTTP::Post.new(uri, headers)
+                          request.body = body
+                          timeout = timeout_ms / 1000
+
+                          response = Net::HTTP.start(uri.hostname, uri.port,
+                                                     use_ssl: uri.scheme == 'https',
+                                                     open_timeout: timeout,
+                                                     write_timeout: timeout,
+                                                     read_timeout: timeout) do |http|
+                            http.request(request)
+                          end
+                          body = response.body
+
+                          JSON.parse(body, symbolize_names: true)
+                        end
+    )
+      @get_api_response = get_api_response
+    end
+
+    public
+
+    Result = Struct.new(:success?, :error_message, :api_response, :data, keyword_init: true)
+
+    def call(params:, api_key:, env: :test, timeout_ms: 5000)
+      endpoint = self.class.endpoint(env: env)
+
+      api_response = get_api_response.call(params: params, api_key: api_key, endpoint: endpoint, timeout_ms: timeout_ms)
+      errors = api_response.dig(:response, :errors)
+
+      if errors.blank?
+        data = api_response.dig(:response, :data)
+
+        Result.new(success?: true, api_response: api_response, data: data)
+      else
+        # Example error response:
+        # {:response=>{:data=>[], :details=>{:requestId=>1}, :errors=>[{:field=>"token", :code=>15, :severity=>2, :msg=>"The referenced resource does not exist", :errorCode=>"no_such_record"}, {:field=>"merchant", :code=>15, :severity=>2, :msg=>"The referenced resource does not exist", :errorCode=>"no_such_record"}]}}
+        message = errors.map do |error|
+          "Field: #{error[:field]}, " \
+          "Code: #{error[:code]}, " \
+          "Severity: #{error[:severity]}, " \
+          "Msg: #{error[:msg]}, " \
+          "ErrorCode: #{error[:errorCode]}"
+        end.uniq.join(', ')
+
+        Result.new(success?: false, error_message: message || 'Error occurred')
+      end
+    rescue JSON::ParserError => e
+      Result.new(success?: false, error_message: "Failed to parse JSON: #{e.message}")
+    rescue Net::OpenTimeout, Net::ReadTimeout, Net::WriteTimeout => e
+      Result.new(success?: false, error_message: "Request timed out: #{e.message}")
+    end
+
+    def self.endpoint(env:)
+      if %i[production staging].include?(env)
+        'https://api.payrix.com/txns'
+      else
+        'https://test-api.payrix.com/txns'
+      end
+    end
+  end
+end

--- a/lib/payrix/create_transaction.rb
+++ b/lib/payrix/create_transaction.rb
@@ -39,7 +39,7 @@ module Payrix
 
     public
 
-    Result = Struct.new(:success?, :error_message, :api_response, :data, keyword_init: true)
+    Result = Struct.new(:success?, :error_message, :error_reason, :api_response, :data, keyword_init: true)
 
     def call(params:, api_key:, env: :test, timeout_ms: 5000)
       endpoint = self.class.endpoint(env: env)
@@ -62,12 +62,12 @@ module Payrix
           "ErrorCode: #{error[:errorCode]}"
         end.uniq.join(', ')
 
-        Result.new(success?: false, error_message: message || 'Error occurred')
+        Result.new(success?: false, error_message: message || 'Error occurred', error_reason: :api_error, api_response: api_response)
       end
     rescue JSON::ParserError => e
-      Result.new(success?: false, error_message: "Failed to parse JSON: #{e.message}")
+      Result.new(success?: false, error_message: "Failed to parse JSON: #{e.message}", error_reason: :json_parse_error)
     rescue Net::OpenTimeout, Net::ReadTimeout, Net::WriteTimeout => e
-      Result.new(success?: false, error_message: "Request timed out: #{e.message}")
+      Result.new(success?: false, error_message: "Request timed out: #{e.message}", error_reason: :timeout)
     end
 
     def self.endpoint(env:)

--- a/lib/payrix/refund_payment.rb
+++ b/lib/payrix/refund_payment.rb
@@ -1,0 +1,60 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+require_relative '../payrix'
+
+module Payrix
+  class RefundPayment
+    private
+
+    attr_reader :create_refund_transaction
+
+    # type 5 - refund - Refund Transaction. Refunds a prior Capture or Sale Transaction (total may be specified for a partial refund)
+    # see: https://resource.payrix.com/resources/refund-or-void-a-transaction-in-the-api#RefundorVoidaTransactionintheAPI-HowtoVoidaPaymentviatheAPI
+    TYPE_REFUND = '5'
+
+    def initialize(
+      create_refund_transaction: lambda do |params:, refund:, api_key:, env:, timeout_ms:|
+        Payrix::CreateTransaction.new.call(
+          params: params.merge({ type: TYPE_REFUND, total: refund.amount }),
+          api_key: api_key,
+          env: env,
+          timeout_ms: timeout_ms
+        )
+      end
+    )
+      @create_refund_transaction = create_refund_transaction
+    end
+
+    public
+
+    Result = Struct.new(:success?, :error_message, :data, keyword_init: true)
+
+    def call(params:, refund:, api_key:, env: :test, timeout_ms: 5000)
+      result = create_refund_transaction.call(params: params, refund: refund, api_key: api_key, env: env, timeout_ms: timeout_ms)
+
+      if result.success?
+        Result.new(success?: true, data: result.data)
+      else
+        Result.new(success?: false, error_message: result.error_message)
+      end
+    end
+
+    # value object for either a full or partial refund. if it's a partial refund, the amount must be specified
+    class Refund
+      REFUND_TYPE_FULL = :full
+      REFUND_TYPE_PARTIAL = :partial
+
+      attr_reader :type, :amount
+
+      def initialize(type:, amount: nil)
+        raise ArgumentError, 'amount must be specified for a partial refund' if type == REFUND_TYPE_PARTIAL && amount.nil?
+        raise ArgumentError, 'amount must not be specified for a full refund' if type == REFUND_TYPE_FULL && amount.present?
+
+        @type = type
+        @amount = amount
+      end
+    end
+  end
+end

--- a/lib/payrix/void_payment.rb
+++ b/lib/payrix/void_payment.rb
@@ -1,0 +1,51 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+require_relative '../payrix'
+
+module Payrix
+  # Makes a FULL REFUND of a payment (NOT a partial, that would require a different service).
+  #
+  # A refund can be issued when the transaction status is "3" (captured) or "4" (settled),
+  # but payments with these statuses cannot be voided or cancelled.
+  # A payment can only be voided or cancelled if the transaction status is "1" (approved).
+  # source: https://resource.payrix.com/resources/refund-or-void-a-transaction-in-the-api
+  class VoidPayment
+    private
+
+    attr_reader :create_void_transaction
+
+    # type 4 - void - Reverse Authorization. Reverses a prior Auth or Sale Transaction and releases the credit hold
+    # type 5 - refund - Refund Transaction. Refunds a prior Capture or Sale Transaction (total may be specified for a partial refund)
+    # see: https://resource.payrix.com/resources/refund-or-void-a-transaction-in-the-api#RefundorVoidaTransactionintheAPI-HowtoVoidaPaymentviatheAPI
+    TYPE_VOID = '4'
+
+    def initialize(
+      create_void_transaction: lambda do |params:, api_key:, env:, timeout_ms:|
+        Payrix::CreateTransaction.new.call(
+          params: params.merge({ type: TYPE_VOID }),
+          api_key: api_key,
+          env: env,
+          timeout_ms: timeout_ms
+        )
+      end
+    )
+      @create_void_transaction = create_void_transaction
+    end
+
+    public
+
+    Result = Struct.new(:success?, :error_message, :data, keyword_init: true)
+
+    def call(params:, api_key:, env: :test, timeout_ms: 5000)
+      result = create_void_transaction.call(params: params, api_key: api_key, env: env, timeout_ms: timeout_ms)
+
+      if result.success?
+        Result.new(success?: true, data: result.data)
+      else
+        Result.new(success?: false, error_message: result.error_message)
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -889,6 +889,11 @@ paypal_signature:
   password: HBC6A84QLRWC923A
   signature: AFcWxV21C7fd0v3bYYYRCpSSRl31AC-11AKBL8FFO9tjImL311y8a0hx
 
+# Working credentials, no need to replace
+payrix:
+  some_credential: SOMECREDENTIAL
+  another_credential: ANOTHERCREDENTIAL
+
 paysafe:
   login: SOMECREDENTIAL
   secret_key: ANOTHERCREDENTIAL

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -889,10 +889,9 @@ paypal_signature:
   password: HBC6A84QLRWC923A
   signature: AFcWxV21C7fd0v3bYYYRCpSSRl31AC-11AKBL8FFO9tjImL311y8a0hx
 
-# Working credentials, no need to replace
 payrix:
-  some_credential: SOMECREDENTIAL
-  another_credential: ANOTHERCREDENTIAL
+  merchant_id: SOMECREDENTIAL
+  api_key: ANOTHERCREDENTIAL
 
 paysafe:
   login: SOMECREDENTIAL

--- a/test/remote/gateways/remote_payrix_test.rb
+++ b/test/remote/gateways/remote_payrix_test.rb
@@ -1,0 +1,146 @@
+require 'test_helper'
+
+class RemotePayrixTest < Test::Unit::TestCase
+  def setup
+    @gateway = PayrixGateway.new(fixtures(:payrix))
+
+    @amount = 100
+    @credit_card = credit_card('4000100011112224')
+    @declined_card = credit_card('4000300011112220')
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'REPLACE WITH SUCCESS MESSAGE', response.message
+  end
+
+  def test_successful_purchase_with_more_options
+    options = {
+      order_id: '1',
+      ip: '127.0.0.1',
+      email: 'joe@example.com'
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'REPLACE WITH SUCCESS MESSAGE', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED PURCHASE MESSAGE', response.message
+  end
+
+  def test_successful_authorize_and_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal 'REPLACE WITH SUCCESS MESSAGE', capture.message
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED AUTHORIZE MESSAGE', response.message
+  end
+
+  def test_partial_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount - 1, auth.authorization)
+    assert_success capture
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(@amount, '')
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED CAPTURE MESSAGE', response.message
+  end
+
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_equal 'REPLACE WITH SUCCESSFUL REFUND MESSAGE', refund.message
+  end
+
+  def test_partial_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount - 1, purchase.authorization)
+    assert_success refund
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, '')
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED REFUND MESSAGE', response.message
+  end
+
+  def test_successful_void
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'REPLACE WITH SUCCESSFUL VOID MESSAGE', void.message
+  end
+
+  def test_failed_void
+    response = @gateway.void('')
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED VOID MESSAGE', response.message
+  end
+
+  def test_successful_verify
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match %r{REPLACE WITH SUCCESS MESSAGE}, response.message
+  end
+
+  def test_failed_verify
+    response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_match %r{REPLACE WITH FAILED PURCHASE MESSAGE}, response.message
+  end
+
+  def test_invalid_login
+    gateway = PayrixGateway.new(login: '', password: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match %r{REPLACE WITH FAILED LOGIN MESSAGE}, response.message
+  end
+
+  def test_dump_transcript
+    # This test will run a purchase transaction on your gateway
+    # and dump a transcript of the HTTP conversation so that
+    # you can use that transcript as a reference while
+    # implementing your scrubbing logic.  You can delete
+    # this helper after completing your scrub implementation.
+    dump_transcript_and_fail(@gateway, @amount, @credit_card, @options)
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+  end
+end

--- a/test/remote/gateways/remote_payrix_test.rb
+++ b/test/remote/gateways/remote_payrix_test.rb
@@ -16,7 +16,7 @@ class RemotePayrixTest < Test::Unit::TestCase
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
-    assert_equal 'REPLACE WITH SUCCESS MESSAGE', response.message
+    assert_equal 'Request Successful', response.message
   end
 
   def test_successful_purchase_with_more_options

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require 'bundler/setup'
 
 require 'test/unit'
 require 'mocha/test_unit'
+require 'byebug'
 
 require 'yaml'
 require 'json'

--- a/test/unit/gateways/payrix_test.rb
+++ b/test/unit/gateways/payrix_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class PayrixTest < Test::Unit::TestCase
   def setup
-    @gateway = PayrixGateway.new(some_credential: 'login', another_credential: 'password')
+    @gateway = PayrixGateway.new(merchant_id: 'SOMECREDENTIAL', api_key: 'ANOTHERCREDENTIAL')
     @credit_card = credit_card
     @amount = 100
 

--- a/test/unit/gateways/payrix_test.rb
+++ b/test/unit/gateways/payrix_test.rb
@@ -58,7 +58,7 @@ class PayrixTest < Test::Unit::TestCase
     response = gateway.purchase(money, payment, options)
 
     assert_failure response
-    assert_equal PayrixGateway::STANDARD_ERROR_CODE[:invalid_credentials], response.error_code
+    assert_equal PayrixGateway::STANDARD_ERROR_CODE[:config_error], response.error_code
   end
 
   def test_purchase

--- a/test/unit/gateways/payrix_test.rb
+++ b/test/unit/gateways/payrix_test.rb
@@ -1,0 +1,107 @@
+require 'test_helper'
+
+class PayrixTest < Test::Unit::TestCase
+  def setup
+    @gateway = PayrixGateway.new(some_credential: 'login', another_credential: 'password')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal 'REPLACE', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+  end
+
+  def test_successful_authorize; end
+
+  def test_failed_authorize; end
+
+  def test_successful_capture; end
+
+  def test_failed_capture; end
+
+  def test_successful_refund; end
+
+  def test_failed_refund; end
+
+  def test_successful_void; end
+
+  def test_failed_void; end
+
+  def test_successful_verify; end
+
+  def test_successful_verify_with_failed_void; end
+
+  def test_failed_verify; end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    '
+      Run the remote tests for this gateway, and then put the contents of transcript.log here.
+    '
+  end
+
+  def post_scrubbed
+    '
+      Put the scrubbed contents of transcript.log here after implementing your scrubbing function.
+      Things to scrub:
+        - Credit card number
+        - CVV
+        - Sensitive authentication details
+    '
+  end
+
+  def successful_purchase_response
+    %(
+      Easy to capture by setting the DEBUG_ACTIVE_MERCHANT environment variable
+      to "true" when running remote tests:
+
+      $ DEBUG_ACTIVE_MERCHANT=true ruby -Itest \
+        test/remote/gateways/remote_payrix_test.rb \
+        -n test_successful_purchase
+    )
+  end
+
+  def failed_purchase_response; end
+
+  def successful_authorize_response; end
+
+  def failed_authorize_response; end
+
+  def successful_capture_response; end
+
+  def failed_capture_response; end
+
+  def successful_refund_response; end
+
+  def failed_refund_response; end
+
+  def successful_void_response; end
+
+  def failed_void_response; end
+end

--- a/test/unit/gateways/payrix_test.rb
+++ b/test/unit/gateways/payrix_test.rb
@@ -61,9 +61,27 @@ class PayrixTest < Test::Unit::TestCase
   private
 
   def pre_scrubbed
-    '
-      Run the remote tests for this gateway, and then put the contents of transcript.log here.
-    '
+    <<-PRE
+    <- "POST /txns HTTP/1.1\r\nContent-Type: application/json\r\nApikey: 60fd52de55d3dede456116800ef6e293\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: test-api.payrix.com\r\nContent-Length: 186\r\n\r\n"
+    <- "{\"merchant\":\"t1_mer_661041feb6b9c04fb7a9ee5\",\"payment\":{\"method\":\"2\",\"number\":\"4000100011112224\",\"cvv\":\"123\"},\"total\":\"1.00\",\"currency\":\"USD\",\"type\":\"1\",\"origin\":\"2\",\"expiration\":\"0120\"}"
+    -> "HTTP/1.1 200 OK\r\n"
+    -> "Date: Mon, 22 Apr 2024 16:15:53 GMT\r\n"
+    -> "Content-Type: application/json; charset=UTF-8\r\n"
+    -> "Transfer-Encoding: chunked\r\n"
+    -> "Connection: close\r\n"
+    -> "Access-Control-Allow-Origin: *\r\n"
+    -> "Access-Control-Max-Age: 1800\r\n"
+    -> "Access-Control-Allow-Methods: GET,PUT,POST,DELETE,OPTIONS\r\n"
+    -> "Access-Control-Allow-Headers: ACCEPT,APIKEY,CONTENT-TYPE,PASSWORD,REQUEST-TOKEN,REQUEST_TOKEN,RESETKEY,SEARCH,SESSIONKEY,TXNSESSIONKEY,TOKEN,TOTALS,USERNAME,X-FORWARDED-FOR\r\n"
+    -> "CF-Cache-Status: DYNAMIC\r\n"
+    -> "Server: cloudflare\r\n"
+    -> "CF-RAY: 8786ea360b6bc409-EWR\r\n"
+    -> "Content-Encoding: gzip\r\n"
+    -> "\r\n"
+    -> "ef\r\n"
+    reading 239 bytes...
+    -> "\x1F\x8B\b\x00\x00\x00\x00\x00\x00\x03\x1C\x8F\xC1j\xC30\x10D\xFFe\xCE:H\xAA\xE38{\xEE\xA5\xE7\xD2S\bF\xB6\xD6\x89 \x92\xDD\x95\xDC\xC6\x18\xFF{QO\x03\xC3{\x03\xB3C8/s\xCA\f\xDA\xE1]q\xA0\xEB\x8E\xC5m\x91S\xA9]\xE4\xF2\x98=\xC8*\xA45\x0E, Xk\e\x1C\n\xC1\x83PL_^\xA9o[\xDBv\xFE\xEDl\xDD\xC94Vs\xC7\xDCM\xD3\x00\x85\xC82>\\]\xABld\xE9\xDB\xD6\xE8\xC6L<\xB4\xC3e\xD4\xCD4\x9C\xDD\x85\xF9\x04\x85\xB2-\f\x82\x81\x02\xBF\x96 \xAE\x849\x81\xA0\x8D\xD5P\x18W\x11N\xE3\x06\xC2\xD7\xE7;\x14f\t\xF7P\x01[\xE5\xB9\xB8'\xC8(\xE4\xDF\xB0\xB0\ai\x05\x8E?\xFF\x99\xC3=\xB9\xB2\n\x83\xF4qS\xF0\\\\x\xE6zQ\xF8{\xE5\\><\xC8\x1C\n,2K\x06]o\xC7\xF1\a\x00\x00\xFF\xFF\x03\x00 \xCD\x03\x1E \x01\x00\x00"
+    PRE
   end
 
   def post_scrubbed

--- a/test/unit/gateways/payrix_test.rb
+++ b/test/unit/gateways/payrix_test.rb
@@ -9,7 +9,10 @@ class PayrixTest < Test::Unit::TestCase
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      type: '1',
+      origin: '2',
+      expiration: '0120'
     }
   end
 
@@ -19,7 +22,7 @@ class PayrixTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
 
-    assert_equal 'REPLACE', response.authorization
+    assert_equal 't1_txn_6626c4364e5731144453863|1', response.authorization
     assert response.test?
   end
 
@@ -28,7 +31,7 @@ class PayrixTest < Test::Unit::TestCase
 
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
-    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+    assert_equal PayrixGateway::STANDARD_ERROR_CODE[:invalid_card_number], response.error_code
   end
 
   def test_successful_authorize; end
@@ -95,17 +98,16 @@ class PayrixTest < Test::Unit::TestCase
   end
 
   def successful_purchase_response
-    %(
-      Easy to capture by setting the DEBUG_ACTIVE_MERCHANT environment variable
-      to "true" when running remote tests:
-
-      $ DEBUG_ACTIVE_MERCHANT=true ruby -Itest \
-        test/remote/gateways/remote_payrix_test.rb \
-        -n test_successful_purchase
-    )
+    <<-RESPONSE
+      {"response":{"data":[{"payment":{"method":2,"number":"2224"},"id":"t1_txn_6626c4364e5731144453863","merchant":"t1_mer_661041feb6b9c04fb7a9ee5","type":"1","expiration":"0120","currency":"USD","origin":"2","total":1,"swiped":0,"emv":0,"signature":0}],"details":{"requestId":1},"errors":[]}}
+    RESPONSE
   end
 
-  def failed_purchase_response; end
+  def failed_purchase_response
+    <<-RESPONSE
+      {"response":{"data":[],"details":{"requestId":1},"errors":[{"field":"payment.number","code":15,"severity":2,"msg":"Invalid credit card/debit card number","errorCode":"invalid_card_number"}]}}
+    RESPONSE
+  end
 
   def successful_authorize_response; end
 

--- a/test/unit/payrix/create_customer_test.rb
+++ b/test/unit/payrix/create_customer_test.rb
@@ -1,0 +1,104 @@
+require 'test_helper'
+require 'payrix/create_customer'
+
+class PayrixCreateCustomerTest < Test::Unit::TestCase
+  def api_key
+    ENV.fetch('PAYRIX_API_KEY_TEST')
+  end
+
+  def test_integration_test_with_payrix_test_api_when_customer_creation_fails_from_errors_field
+    service = Payrix::CreateCustomer.new(
+      post_customer: lambda { |*|
+        { errors: [{ field: 'email', msg: 'Invalid email format' }] }
+      }
+    )
+
+    result = service.call(
+      params: { firstName: 'John', lastName: 'Doe', email: 'invalid-email' },
+      api_key: api_key
+    )
+
+    assert_equal false, result.success?
+    assert result.error_message.include?('Invalid email format')
+  end
+
+  def test_integration_test_with_payrix_test_api_when_customer_creation_fails_from_response_errors_field
+    service = Payrix::CreateCustomer.new(
+      post_customer: lambda { |*|
+        { response: { errors: [{ field: 'email', msg: 'Invalid email format' }] } }
+      }
+    )
+
+    result = service.call(
+      params: { firstName: 'John', lastName: 'Doe', email: 'invalid-email' },
+      api_key: api_key
+    )
+
+    assert_equal false, result.success?
+    assert result.error_message.include?('Invalid email format')
+  end
+
+  def test_works_with_success_response
+    service = Payrix::CreateCustomer.new(
+      post_customer: lambda { |*|
+        {
+          response: {
+            success: true,
+            data: {
+              id: 'cust123',
+              firstName: 'John',
+              lastName: 'Doe',
+              email: 'john.doe@example.com'
+            }
+          }
+        }
+      }
+    )
+
+    result = service.call(
+      params: { firstName: 'John', lastName: 'Doe', email: 'john.doe@example.com' },
+      api_key: api_key
+    )
+
+    assert result.error_message.blank?
+    assert result.success?
+    assert_equal 'cust123', result.data[:id]
+    assert_equal 'John', result.data[:firstName]
+    assert_equal 'Doe', result.data[:lastName]
+    assert_equal 'john.doe@example.com', result.data[:email]
+  end
+
+  def test_returns_a_details_error_message_when_the_api_call_fails_due_to_an_error_response
+    service = Payrix::CreateCustomer.new(
+      post_customer: lambda { |*|
+                       {
+                         response: {
+                           errors: [
+                             { field: 'email', msg: 'Invalid email format' }
+                           ]
+                         }
+                       }
+                     }
+    )
+
+    result = service.call(
+      params: { firstName: 'John', lastName: 'Doe', email: 'invalid-email' },
+      api_key: api_key
+    )
+
+    assert result.error_message.include?('email: Invalid email format')
+    assert_equal false, result.success?
+  end
+
+  def test_handles_timeouts_appropriately
+    service = Payrix::CreateCustomer.new(post_customer: ->(*) { raise Net::ReadTimeout })
+
+    result = service.call(
+      params: { firstName: 'John', lastName: 'Doe', email: 'john.doe@example.com' },
+      api_key: api_key
+    )
+
+    assert result.error_message.include?('Request timed out')
+    assert_equal false, result.success?
+  end
+end

--- a/test/unit/payrix/create_refund_test.rb
+++ b/test/unit/payrix/create_refund_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+require 'payrix/create_refund'
+
+class PayrixCreateRefundTest < Test::Unit::TestCase
+  def api_key
+    ENV.fetch("PAYRIX_API_KEY_TEST")
+  end
+
+  def test_integration_test_with_payrix_test_api_when_entry_doesnt_exist
+    service = Payrix::CreateRefund.new
+
+    result = service.call(entry_id: 'entry123', amount: 1000, description: 'Refund for overcharge', api_key: api_key)
+
+    assert result.error_message.include?('entry: The referenced resource does not exist')
+    assert_equal false, result.success?
+  end
+
+  def test_works_with_success_response
+    response_body = {
+      response: {
+        success: true,
+        data: {
+          id: 'refund123',
+          amount: 1000,
+          entry: 'entry123',
+          description: 'Refund for overcharge'
+        }
+      }
+    }
+    service = Payrix::CreateRefund.new(post_refund: ->(*) { response_body })
+
+    result = service.call(entry_id: 'entry123',
+                          amount: 1000,
+                          description: 'Refund for overcharge',
+                          api_key: api_key)
+
+    assert result.error_message.blank?
+    assert result.success?
+    assert_equal 'refund123', response_body[:response][:data][:id]
+    assert_equal 1000, response_body[:response][:data][:amount]
+    assert_equal 'entry123', response_body[:response][:data][:entry]
+    assert_equal 'Refund for overcharge', response_body[:response][:data][:description]
+  end
+
+  def test_returns_a_details_error_message_when_the_api_call_fails_due_to_an_error_response
+    response_body = {
+      response: {
+        errors: [
+          { field: 'amount', msg: 'Invalid amount' },
+          { field: 'entry', msg: 'Entry not found' }
+        ]
+      }
+    }
+    service = Payrix::CreateRefund.new(post_refund: ->(*) { response_body })
+
+    result = service.call(entry_id: 'entry123',
+                          amount: 1000,
+                          description: 'Refund for overcharge',
+                          api_key: api_key)
+
+    assert result.error_message.include?('amount: Invalid amount')
+    assert result.error_message.include?('entry: Entry not found')
+    assert_equal false, result.success?
+  end
+
+  def test_returns_an_error_message_when_the_api_call_fails_due_to_an_error_response
+    service = Payrix::CreateRefund.new(post_refund: ->(*) { raise Net::ReadTimeout })
+
+    result = service.call(entry_id: 'entry123',
+                          amount: 1000,
+                          description: 'Refund for overcharge',
+                          api_key: api_key)
+
+    assert result.error_message.include?('Request timed out')
+    assert_equal false, result.success?
+  end
+end

--- a/test/unit/payrix/create_transaction_test.rb
+++ b/test/unit/payrix/create_transaction_test.rb
@@ -1,0 +1,187 @@
+require 'test_helper'
+require 'payrix/create_transaction'
+
+class PayrixCreateTransactionTest < Test::Unit::TestCase
+  def test_env_merchant_id
+    't1_mer_661041feb6b9c04fb7a9ee5'
+  end
+
+  def api_key
+    ENV.fetch('PAYRIX_API_KEY_TEST')
+  end
+
+  def test_integration_test_with_payrix_test_api
+    service = Payrix::CreateTransaction.new
+
+    result = service.call(
+      api_key: api_key,
+      params: {
+        merchant: test_env_merchant_id,
+        type: '1',
+        origin: '2',
+        total: 1000,
+        expiration: '0120',
+        payment: {
+          method: 2,
+          number: '4111111111111111',
+          cvv: '111'
+        }
+      }
+    )
+
+    assert result.success?
+    expected_response = { response: {
+      data: [{
+        payment: { method: 2, number: '1111' },
+        id: 't1_txn_661eda69cf8834846219121', merchant: test_env_merchant_id,
+        type: '1', expiration: '0120', origin: '2', total: 1000,
+        swiped: 0, emv: 0, signature: 0
+      }],
+      details: { requestId: 1 },
+      errors: []
+    } }
+    assert_equal expected_response[:response][:data][0][:merchant], result.api_response[:response][:data][0][:merchant]
+    assert_match(/^t1_txn_/, result.data.first[:id])
+  end
+
+  def test_successfully_creates_a_transaction_and_checks_detailed_data
+    params = {
+      merchant: test_env_merchant_id,
+      type: '1',
+      origin: '2',
+      token: 'e41272ec5464d9ec81cc85c854837472',
+      total: 100
+    }
+    service = Payrix::CreateTransaction.new(
+      get_api_response: lambda { |*|
+                          {
+                            response: {
+                              data: [{
+                                payment: { method: 2, number: '1111' },
+                                id: 't1_txn_661eda69cf8834846219121', merchant: test_env_merchant_id,
+                                type: '1', expiration: '0120', origin: '2', total: 1000,
+                                swiped: 0, emv: 0, signature: 0
+                              }],
+                              details: { requestId: 1 },
+                              errors: []
+                            }
+                          }
+                        }
+    )
+
+    result = service.call(params: params, api_key: api_key)
+
+    assert result.success?
+    assert_equal(
+      {
+        response: {
+          data: [
+            { emv: 0, expiration: '0120', id: 't1_txn_661eda69cf8834846219121',
+              merchant: 't1_mer_661041feb6b9c04fb7a9ee5', origin: '2',
+              payment: { method: 2, number: '1111' }, signature: 0, swiped: 0, total: 1000, type: '1' }
+          ], details: { requestId: 1 }, errors: []
+        }
+      }, result.api_response
+    )
+  end
+
+  def test_returns_an_error_response_when_the_api_call_fails_due_to_an_error_response
+    service = Payrix::CreateTransaction.new(
+      get_api_response: lambda { |*|
+                          { response: {
+                            data: [],
+                            details: { requestId: 1 },
+                            errors: [
+                              { field: 'token', code: 15, severity: 2, msg: 'The referenced resource does not exist',
+                                errorCode: 'no_such_record' },
+                              { field: 'merchant', code: 15, severity: 2,
+                                msg: 'The referenced resource does not exist', errorCode: 'no_such_record' }
+                            ]
+                          } }
+                        }
+    )
+
+    result = service.call(
+      api_key: api_key,
+      params: {
+        merchant: test_env_merchant_id,
+        type: '1',
+        origin: '2',
+        token: 'e41272ec5464d9ec81cc85c854837472',
+        total: 100
+      }
+    )
+
+    assert_false result.success?
+    assert_equal 'Field: token, Code: 15, Severity: 2, Msg: The referenced resource does not exist, ErrorCode: no_such_record, Field: merchant, Code: 15, Severity: 2, Msg: The referenced resource does not exist, ErrorCode: no_such_record', result.error_message
+  end
+
+  def test_handles_timeouts_appropriately
+    service = Payrix::CreateTransaction.new(
+      get_api_response: ->(*) { raise Net::ReadTimeout }
+    )
+
+    result = service.call(
+      api_key: api_key,
+      params: {
+        merchant: test_env_merchant_id,
+        type: '1',
+        origin: '2',
+        token: 'e41272ec5464d9ec81cc85c854837472',
+        total: 100
+      }
+    )
+
+    assert_false result.success?
+    assert_match(/Request timed out/, result.error_message)
+  end
+
+  def test_handles_json_parsing_errors_appropriately
+    service = Payrix::CreateTransaction.new(
+      get_api_response: ->(*) { raise JSON::ParserError, 'unexpected token' }
+    )
+
+    result = service.call(
+      api_key: api_key,
+      params: {
+        merchant: test_env_merchant_id,
+        type: '1',
+        origin: '2',
+        token: 'e41272ec5464d9ec81cc85c854837472',
+        total: 100,
+        api_key: api_key
+      }
+    )
+
+    assert_false result.success?
+    assert_match(/Failed to parse JSON/, result.error_message)
+  end
+
+  def test_params
+    {
+      merchant: test_env_merchant_id,
+      type: '1',
+      origin: '2',
+      token: 'e41272ec5464d9ec81cc85c854837472',
+      total: 100
+    }
+  end
+
+  def test_uses_the_correct_endpoint_in_production
+    result = Payrix::CreateTransaction.endpoint(env: :production)
+
+    assert_equal 'https://api.payrix.com/txns', result
+  end
+
+  def test_uses_the_correct_endpoint_in_development
+    result = Payrix::CreateTransaction.endpoint(env: :development)
+
+    assert_equal 'https://test-api.payrix.com/txns', result
+  end
+
+  def test_uses_the_correct_endpoint_in_staging
+    result = Payrix::CreateTransaction.endpoint(env: :staging)
+
+    assert_equal 'https://api.payrix.com/txns', result
+  end
+end

--- a/test/unit/payrix/create_transaction_test.rb
+++ b/test/unit/payrix/create_transaction_test.rb
@@ -3,7 +3,7 @@ require 'payrix/create_transaction'
 
 class PayrixCreateTransactionTest < Test::Unit::TestCase
   def test_env_merchant_id
-    't1_mer_661041feb6b9c04fb7a9ee5'
+    ENV.fetch('PAYRIX_MERCHANT_ID_TEST')
   end
 
   def api_key
@@ -77,7 +77,7 @@ class PayrixCreateTransactionTest < Test::Unit::TestCase
         response: {
           data: [
             { emv: 0, expiration: '0120', id: 't1_txn_661eda69cf8834846219121',
-              merchant: 't1_mer_661041feb6b9c04fb7a9ee5', origin: '2',
+              merchant: test_env_merchant_id, origin: '2',
               payment: { method: 2, number: '1111' }, signature: 0, swiped: 0, total: 1000, type: '1' }
           ], details: { requestId: 1 }, errors: []
         }

--- a/test/unit/payrix/refund_payment_test.rb
+++ b/test/unit/payrix/refund_payment_test.rb
@@ -1,0 +1,120 @@
+require 'test_helper'
+require 'payrix/refund_payment'
+require 'payrix/create_transaction'
+
+class PayrixRefundPaymentTest < Test::Unit::TestCase
+  def api_key
+    ENV.fetch('PAYRIX_API_KEY_TEST')
+  end
+
+  def test_full_refund_integration_test_no_stubs
+    service = Payrix::RefundPayment.new
+
+    result = service.call(
+      params: { transactionId: 'txn123' },
+      api_key: api_key,
+      refund: Payrix::RefundPayment::Refund.new(type: :full)
+    )
+
+    # TODO: do whatever setup of resources is necessary to make this test pass in Payrix test 
+    assert_equal false, result.success?
+    #<struct Payrix::VoidPayment::Result :success?=false, error_message="Field: fortxn, Code: 15, Severity: 2, Msg: This field is required to be set, ErrorCode: required_field, Field: origin, Code: 15, Severity: 2, Msg: This field is required to be set, ErrorCode: required_field, Field: merchant, Code: 15, Severity: 2, Msg: The referenced resource does not exist, ErrorCode: no_such_record, Field: total, Code: 15, Severity: 2, Msg: This field is required to be set, ErrorCode: required_field", data=nil>
+    assert result.error_message.include?('This field is required to be set')
+  end
+
+  def test_partial_refund_integration_test_no_stubs
+    service = Payrix::RefundPayment.new
+
+    result = service.call(
+      params: { transactionId: 'txn123' },
+      api_key: api_key,
+      refund: Payrix::RefundPayment::Refund.new(type: :partial, amount: 1000)
+    )
+
+    # TODO: do whatever setup of resources is necessary to make this test pass in Payrix test env
+    assert_equal false, result.success?
+    #<struct Payrix::VoidPayment::Result :success?=false, error_message="Field: fortxn, Code: 15, Severity: 2, Msg: This field is required to be set, ErrorCode: required_field, Field: origin, Code: 15, Severity: 2, Msg: This field is required to be set, ErrorCode: required_field, Field: merchant, Code: 15, Severity: 2, Msg: The referenced resource does not exist, ErrorCode: no_such_record, Field: total, Code: 15, Severity: 2, Msg: This field is required to be set, ErrorCode: required_field", data=nil>
+    assert result.error_message.include?('This field is required to be set')
+  end
+
+  def test_full_refund
+    service = Payrix::RefundPayment.new(
+      create_refund_transaction: lambda { |*|
+        Payrix::CreateTransaction::Result.new(
+          success?: true,
+          data: {
+            id: 'void123',
+            transactionStatus: '5'
+          }
+        )
+      }
+    )
+
+    result = service.call(
+      params: { transactionId: 'txn123' },
+      api_key: api_key,
+      refund: Payrix::RefundPayment::Refund.new(type: :full)
+    )
+
+    assert_equal true, result.success?
+    assert_equal 'void123', result.data[:id]
+    assert_equal '5', result.data[:transactionStatus]
+  end
+
+  def test_partial_refund
+    service = Payrix::RefundPayment.new(
+      create_refund_transaction: lambda { |*|
+        Payrix::CreateTransaction::Result.new(
+          success?: true,
+          data: {
+            id: 'void123',
+            transactionStatus: '5'
+          }
+        )
+      }
+    )
+    amount = 1000
+
+    result = service.call(
+      params: { transactionId: 'txn123' },
+      api_key: api_key,
+      refund: Payrix::RefundPayment::Refund.new(type: :partial, amount: amount)
+    )
+
+    assert_equal true, result.success?
+    assert_equal 'void123', result.data[:id]
+    assert_equal '5', result.data[:transactionStatus]
+  end
+
+  def test_errors_when_amount_is_specified_for_full_refund
+    assert_raises ArgumentError do
+      Payrix::RefundPayment::Refund.new(type: :full, amount: 1000)
+    end
+  end
+
+  def test_errors_when_amount_is_not_specified_for_partial_refund
+    assert_raises ArgumentError do
+      Payrix::RefundPayment::Refund.new(type: :partial)
+    end
+  end
+
+  def test_errors_on_invalid_transaction_id
+    service = Payrix::RefundPayment.new(
+      create_refund_transaction: lambda { |*|
+        Payrix::CreateTransaction::Result.new(
+          success?: false,
+          error_message: 'Invalid transaction ID'
+        )
+      }
+    )
+
+    result = service.call(
+      params: { transactionId: 'invalid123' },
+      api_key: api_key,
+      refund: Payrix::RefundPayment::Refund.new(type: :full)
+    )
+
+    refute result.success?
+    assert result.error_message.include?('Invalid transaction ID')
+  end
+end

--- a/test/unit/payrix/void_payment_test.rb
+++ b/test/unit/payrix/void_payment_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+require 'payrix/void_payment'
+require 'payrix/create_transaction'
+
+class PayrixVoidPaymentTest < Test::Unit::TestCase
+  def api_key
+    ENV.fetch('PAYRIX_API_KEY_TEST')
+  end
+
+  def test_integration_test_no_stubs
+    service = Payrix::VoidPayment.new
+
+    result = service.call(
+      params: { transactionId: 'txn123' },
+      api_key: api_key
+    )
+
+    assert_equal false, result.success?
+    #<struct Payrix::VoidPayment::Result :success?=false, error_message="Field: fortxn, Code: 15, Severity: 2, Msg: This field is required to be set, ErrorCode: required_field, Field: origin, Code: 15, Severity: 2, Msg: This field is required to be set, ErrorCode: required_field, Field: merchant, Code: 15, Severity: 2, Msg: The referenced resource does not exist, ErrorCode: no_such_record, Field: total, Code: 15, Severity: 2, Msg: This field is required to be set, ErrorCode: required_field", data=nil>
+    assert result.error_message.include?('This field is required to be set')
+  end
+
+  def test_voids_a_payment
+    service = Payrix::VoidPayment.new(
+      create_void_transaction: lambda { |*|
+        Payrix::CreateTransaction::Result.new(
+          success?: true,
+          data: {
+            id: 'void123',
+            transactionStatus: '4'
+          }
+        )
+      }
+    )
+
+    result = service.call(
+      params: { transactionId: 'txn123' },
+      api_key: api_key
+    )
+
+    assert_equal true, result.success?
+    assert_equal 'void123', result.data[:id]
+    assert_equal '4', result.data[:transactionStatus]
+  end
+
+  def test_errors_on_invalid_transaction_id
+    service = Payrix::VoidPayment.new(
+      create_void_transaction: lambda { |*|
+        Payrix::CreateTransaction::Result.new(
+          success?: false,
+          error_message: 'Invalid transaction ID'
+        )
+      }
+    )
+
+    result = service.call(
+      params: { transactionId: 'invalid123' },
+      api_key: api_key
+    )
+
+    refute result.success?
+    assert result.error_message.include?('Invalid transaction ID')
+  end
+end


### PR DESCRIPTION
Pull Request moved to https://github.com/givehub/active_merchant/pull/4

### Summary 

Payrix Gateway

### Tasks
Payrix Gateway support for:

- [ ] Authorize
- [ ] Capture
- [ ] Purchase 
- [ ] Void
- [ ] Refund
- [ ] Verify
- [ ] Data `scrub`

Reference implementation: [Cybersource REST Active Merchant gateway](https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/cyber_source_rest.rb)

### [Testing](https://github.com/activemerchant/active_merchant/wiki/Testing-Your-Gateway)

#### Unit Tests

```console 
bundle exec rake test:units TEST=test/unit/gateways/payrix_test.rb
```

- [x] Purchase
- [ ] Refund

#### Remote Tests
```console 
bundle exec rake test:remote TEST=test/remote/gateways/remote_payrix_test.rb
```

### References
[Payrix API (/txns)](https://portal.payrix.com/docs/api#txnsPost)